### PR TITLE
Multi-state message object does not have data parameter

### DIFF
--- a/examples/data_channel/multiplestate/multiplestate.py
+++ b/examples/data_channel/multiplestate/multiplestate.py
@@ -52,7 +52,7 @@ async def main():
 
         # Define a callback function to handle multiplestate when received.
         def multiplestate_callback(message):
-            current_message = message['data']
+            current_message = message
             
             display_data(current_message)
 


### PR DESCRIPTION
The fix allows multiple state messages to come in normally. Without it, it prints nothing.