### PR TITLE
Fixed incorrect RTC Topic

### DIFF
--- a/examples/data_channel/sportmode/sportmode.py
+++ b/examples/data_channel/sportmode/sportmode.py
@@ -36,7 +36,7 @@ async def main():
         if current_motion_switcher_mode != "normal":
             print(f"Switching motion mode from {current_motion_switcher_mode} to 'normal'...")
             await conn.datachannel.pub_sub.publish_request_new(
-                RTC_TOPIC["MOTION_SWITCHER"], 
+                RTC_TOPIC["SPORT_MOD"], 
                 {
                     "api_id": 1002,
                     "parameter": {"name": "normal"}


### PR DESCRIPTION
Without this, the dog will have locked joints after "joint-locking" commands such as "StandUp", causing rear motors to overheat quickly, and preventing some commands such as movement.
This issue does not show when rebooting the dog as it would be in a non-joint locked state, but may appear if the code is restarted while the dog is in a joint-locked state.