### PR TITLE
Error handler patch

### DIFF
--- a/go2_webrtc_driver/msgs/error_handler.py
+++ b/go2_webrtc_driver/msgs/error_handler.py
@@ -90,3 +90,29 @@ def handle_error(message):
             f"🕒 Time:          {readable_time}\n"
             f"🔢 Error Source:  {error_source_text}\n"
             f"❗ Error Code:    {error_code_text}\n")
+
+def handle_single_error(message):
+    """
+    Handle the error message, print the time, error source, and error message.
+
+    Args:
+        message (dict): The error message containing the data field.
+    """
+
+    timestamp, error_source, error_code_int = message["data"]
+
+    # Convert the timestamp to human-readable format
+    readable_time = time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(timestamp))
+
+    error_source_text = get_error_source_text(error_source)
+
+    # Convert the error code to a hexadecimal string
+    error_code_hex = integer_to_hex_string(error_code_int)
+
+    # Get the error message
+    error_code_text = get_error_code_text(error_source, error_code_hex)
+
+    print(f"\n🚨 Error Received from Go2:\n"
+        f"🕒 Time:          {readable_time}\n"
+        f"🔢 Error Source:  {error_source_text}\n"
+        f"❗ Error Code:    {error_code_text}\n")

--- a/go2_webrtc_driver/webrtc_datachannel.py
+++ b/go2_webrtc_driver/webrtc_datachannel.py
@@ -93,8 +93,10 @@ class WebRTCDataChannel:
             self.rtc_inner_req.handle_response(msg)
         elif msg_type == DATA_CHANNEL_TYPE["HEARTBEAT"]:
             self.heartbeat.handle_response(msg)
-        elif msg_type in {DATA_CHANNEL_TYPE["ERRORS"], DATA_CHANNEL_TYPE["ADD_ERROR"], DATA_CHANNEL_TYPE["RM_ERROR"]}:
+        elif msg_type == DATA_CHANNEL_TYPE["ERRORS"]:
             handle_error(msg)
+        elif msg_type in {DATA_CHANNEL_TYPE["ADD_ERROR"], DATA_CHANNEL_TYPE["RM_ERROR"]}:
+            handle_single_error(msg)
         elif msg_type == DATA_CHANNEL_TYPE["ERR"]:
             await self.validaton.handle_err_response(msg)
         


### PR DESCRIPTION
Hi @legion1581 

Thank you so much for this repository.

This is a small patch, with a somewhat dirty hack for an issue I have been facing.

It turns out that messages in `add_error` or `rm_error` types come as a single list, with `timestamp, error_source, error_code_int` packed into a list. However, in https://github.com/legion1581/go2_webrtc_connect/blob/master/go2_webrtc_driver/msgs/error_handler.py#L66 it is expected to get, I assume, a list of lists to unpack.

I am not sure what happens with normal errors, but `add, and `rm` types raise a `TypeError` when handling the message.

Feel free to discard the PR, as I didn't have a way to test other errors, and it could be done in a much more efficient way.


