### PR TITLE
Example fixes

### DIFF
--- a/examples/audio/live_audio/live_recv_audio.py
+++ b/examples/audio/live_audio/live_recv_audio.py
@@ -4,7 +4,6 @@ import numpy as np
 import pyaudio
 import sys
 from go2_webrtc_driver.webrtc_driver import Go2WebRTCConnection, WebRTCConnectionMethod
-from go2_webrtc_driver.webrtc_video import MediaHandler
 
 # Enable logging for debugging
 logging.basicConfig(level=logging.FATAL)

--- a/examples/audio/save_audio/save_audio_to_file.py
+++ b/examples/audio/save_audio/save_audio_to_file.py
@@ -4,7 +4,6 @@ import wave
 import numpy as np
 import sys
 from go2_webrtc_driver.webrtc_driver import Go2WebRTCConnection, WebRTCConnectionMethod
-from go2_webrtc_driver.webrtc_video import MediaHandler
 
 # Enable logging for debugging
 logging.basicConfig(level=logging.FATAL)


### PR DESCRIPTION
Howdy, thanks for this repo. I was able to run all of the examples with a Go2 EDU, but had to make a couple of small changes:

* [x] removed MediaHandler import from `live_audio` and `save_audio` examples. It doesn't exist in the API and I assume was refactored out at some point. Both examples seem to work fine without.
* [x]  added 'lz4' module to setup.py for the 'lidar' example
* [x] added 'pydub' module to setup.py for the 'save_audio` example

I am unsure about adding the last two to setup.py since they are only needed by the specific examples. Maybe it's enough to note this via readmes and/or comments in the example header for each?