### PR TITLE
Allow setting the robot IP using an environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,11 @@ The driver supports three types of connection methods:
     UnitreeWebRTCConnection(WebRTCConnectionMethod.LocalSTA, ip="192.168.8.181")
     ```
 
+    Alternatively, you can set the environement variable `ROBOT_IP`, for example
+
+    ```bash
+    export ROBOT_IP="192.168.8.181"
+    ```
 
     If the IP is unknown, you can specify only the serial number, and the driver will try to find the IP using the special Multicast discovery feature available on Go2:
 
@@ -76,7 +81,7 @@ pip install -e .
 ```
 
 ## Usage 
-Example programs are located in the /example directory.
+Example programs are located in the /example directory. Set the IP address of the robot using the environment variable `ROBOT_IP` or modify the example.
 
 ### Thanks
 

--- a/examples/go2/audio/internet_radio/stream_radio.py
+++ b/examples/go2/audio/internet_radio/stream_radio.py
@@ -10,7 +10,7 @@ logging.basicConfig(level=logging.FATAL)
 
 async def main():
     try:
-        conn = UnitreeWebRTCConnection(WebRTCConnectionMethod.LocalSTA, ip="192.168.8.181")
+        conn = UnitreeWebRTCConnection(WebRTCConnectionMethod.LocalSTA)
         # conn = UnitreeWebRTCConnection(WebRTCConnectionMethod.LocalSTA, serialNumber="B42D2000XXXXXXXX")
         # conn = UnitreeWebRTCConnection(WebRTCConnectionMethod.Remote, serialNumber="B42D2000XXXXXXXX", username="email@gmail.com", password="pass")
         # conn = UnitreeWebRTCConnection(WebRTCConnectionMethod.LocalAP)

--- a/examples/go2/audio/live_audio/live_recv_audio.py
+++ b/examples/go2/audio/live_audio/live_recv_audio.py
@@ -35,7 +35,7 @@ async def recv_audio_stream(frame):
 async def main():
     try:
         # Choose a connection method (uncomment the correct one)
-        conn = UnitreeWebRTCConnection(WebRTCConnectionMethod.LocalSTA, ip="192.168.8.181")
+        conn = UnitreeWebRTCConnection(WebRTCConnectionMethod.LocalSTA)
         # conn = UnitreeWebRTCConnection(WebRTCConnectionMethod.LocalSTA, serialNumber="B42D2000XXXXXXXX")
         # conn = UnitreeWebRTCConnection(WebRTCConnectionMethod.Remote, serialNumber="B42D2000XXXXXXXX", username="email@gmail.com", password="pass")
         # conn = UnitreeWebRTCConnection(WebRTCConnectionMethod.LocalAP)

--- a/examples/go2/audio/mp3_player/play_mp3.py
+++ b/examples/go2/audio/mp3_player/play_mp3.py
@@ -12,7 +12,7 @@ logging.basicConfig(level=logging.FATAL)
 async def main():
     try:
         # Choose a connection method (uncomment the correct one)
-        conn = UnitreeWebRTCConnection(WebRTCConnectionMethod.LocalSTA, ip="192.168.8.181")
+        conn = UnitreeWebRTCConnection(WebRTCConnectionMethod.LocalSTA)
         # conn = UnitreeWebRTCConnection(WebRTCConnectionMethod.LocalSTA, serialNumber="B42D2000XXXXXXXX")
         # conn = UnitreeWebRTCConnection(WebRTCConnectionMethod.Remote, serialNumber="B42D2000XXXXXXXX", username="email@gmail.com", password="pass")
         # conn = UnitreeWebRTCConnection(WebRTCConnectionMethod.LocalAP)

--- a/examples/go2/audio/save_audio/save_audio_to_file.py
+++ b/examples/go2/audio/save_audio/save_audio_to_file.py
@@ -50,7 +50,7 @@ async def recv_audio_stream(frame):
 async def main():
     try:
         # Choose a connection method (uncomment the correct one)
-        conn = UnitreeWebRTCConnection(WebRTCConnectionMethod.LocalSTA, ip="192.168.8.181")
+        conn = UnitreeWebRTCConnection(WebRTCConnectionMethod.LocalSTA)
         # conn = UnitreeWebRTCConnection(WebRTCConnectionMethod.LocalSTA, serialNumber="B42D2000XXXXXXXX")
         # conn = UnitreeWebRTCConnection(WebRTCConnectionMethod.Remote, serialNumber="B42D2000XXXXXXXX", username="email@gmail.com", password="pass")
         # conn = UnitreeWebRTCConnection(WebRTCConnectionMethod.LocalAP)

--- a/examples/go2/data_channel/lidar/lidar_stream.py
+++ b/examples/go2/data_channel/lidar/lidar_stream.py
@@ -9,7 +9,7 @@ logging.basicConfig(level=logging.FATAL)
 async def main():
     try:
         # Choose a connection method (uncomment the correct one)
-        conn = UnitreeWebRTCConnection(WebRTCConnectionMethod.LocalSTA, ip="192.168.8.181")
+        conn = UnitreeWebRTCConnection(WebRTCConnectionMethod.LocalSTA)
         # conn = UnitreeWebRTCConnection(WebRTCConnectionMethod.LocalSTA, serialNumber="B42D2000XXXXXXXX")
         # conn = UnitreeWebRTCConnection(WebRTCConnectionMethod.Remote, serialNumber="B42D2000XXXXXXXX", username="email@gmail.com", password="pass")
         # conn = UnitreeWebRTCConnection(WebRTCConnectionMethod.LocalAP)

--- a/examples/go2/data_channel/lidar/plot_lidar_stream.py
+++ b/examples/go2/data_channel/lidar/plot_lidar_stream.py
@@ -130,7 +130,7 @@ async def lidar_webrtc_connection():
 
     while retry_attempts < MAX_RETRY_ATTEMPTS:
         try:
-            conn = UnitreeWebRTCConnection(WebRTCConnectionMethod.LocalSTA, ip="192.168.8.181")  # WebRTC IP
+            conn = UnitreeWebRTCConnection(WebRTCConnectionMethod.LocalSTA)  # WebRTC IP
             # _webrtc_connection = UnitreeWebRTCConnection(WebRTCConnectionMethod.Remote, serialNumber="B42D2000XXXXXXXX", username="email@gmail.com", password="pass")
             # _webrtc_connection = UnitreeWebRTCConnection(WebRTCConnectionMethod.LocalAP)
 

--- a/examples/go2/data_channel/lowstate/lowstate.py
+++ b/examples/go2/data_channel/lowstate/lowstate.py
@@ -58,7 +58,7 @@ def display_data(message):
 async def main():
     try:
         # Choose a connection method (uncomment the correct one)
-        conn = UnitreeWebRTCConnection(WebRTCConnectionMethod.LocalSTA, ip="192.168.8.181")
+        conn = UnitreeWebRTCConnection(WebRTCConnectionMethod.LocalSTA)
         # conn = UnitreeWebRTCConnection(WebRTCConnectionMethod.LocalSTA, serialNumber="B42D2000XXXXXXXX")
         # conn = UnitreeWebRTCConnection(WebRTCConnectionMethod.Remote, serialNumber="B42D2000XXXXXXXX", username="email@gmail.com", password="pass")
         # conn = UnitreeWebRTCConnection(WebRTCConnectionMethod.LocalAP)

--- a/examples/go2/data_channel/multiplestate/multiplestate.py
+++ b/examples/go2/data_channel/multiplestate/multiplestate.py
@@ -41,7 +41,7 @@ def display_data(message):
 async def main():
     try:
         # Choose a connection method (uncomment the correct one)
-        conn = UnitreeWebRTCConnection(WebRTCConnectionMethod.LocalSTA, ip="192.168.8.181")
+        conn = UnitreeWebRTCConnection(WebRTCConnectionMethod.LocalSTA)
         # conn = UnitreeWebRTCConnection(WebRTCConnectionMethod.LocalSTA, serialNumber="B42D2000XXXXXXXX")
         # conn = UnitreeWebRTCConnection(WebRTCConnectionMethod.Remote, serialNumber="B42D2000XXXXXXXX", username="email@gmail.com", password="pass")
         # conn = UnitreeWebRTCConnection(WebRTCConnectionMethod.LocalAP)

--- a/examples/go2/data_channel/sportmode/sportmode.py
+++ b/examples/go2/data_channel/sportmode/sportmode.py
@@ -11,7 +11,7 @@ logging.basicConfig(level=logging.FATAL)
 async def main():
     try:
         # Choose a connection method (uncomment the correct one)
-        conn = UnitreeWebRTCConnection(WebRTCConnectionMethod.LocalSTA, ip="192.168.8.181")
+        conn = UnitreeWebRTCConnection(WebRTCConnectionMethod.LocalSTA)
         # conn = UnitreeWebRTCConnection(WebRTCConnectionMethod.LocalSTA, serialNumber="B42D2000XXXXXXXX")
         # conn = UnitreeWebRTCConnection(WebRTCConnectionMethod.Remote, serialNumber="B42D2000XXXXXXXX", username="email@gmail.com", password="pass")
         # conn = UnitreeWebRTCConnection(WebRTCConnectionMethod.LocalAP)

--- a/examples/go2/data_channel/sportmodestate/sportmodestate.py
+++ b/examples/go2/data_channel/sportmodestate/sportmodestate.py
@@ -62,7 +62,7 @@ def display_data(message):
 async def main():
     try:
         # Choose a connection method (uncomment the correct one)
-        conn = UnitreeWebRTCConnection(WebRTCConnectionMethod.LocalSTA, ip="192.168.0.181")
+        conn = UnitreeWebRTCConnection(WebRTCConnectionMethod.LocalSTA)
         # conn = UnitreeWebRTCConnection(WebRTCConnectionMethod.LocalSTA, serialNumber="B42D2000XXXXXXXX")
         # conn = UnitreeWebRTCConnection(WebRTCConnectionMethod.Remote, serialNumber="B42D2000XXXXXXXX", username="email@gmail.com", password="pass")
         # conn = UnitreeWebRTCConnection(WebRTCConnectionMethod.LocalAP)

--- a/examples/go2/data_channel/vui/vui.py
+++ b/examples/go2/data_channel/vui/vui.py
@@ -12,7 +12,7 @@ logging.basicConfig(level=logging.FATAL)
 async def main():
     try:
         # Choose a connection method (uncomment the correct one)
-        conn = UnitreeWebRTCConnection(WebRTCConnectionMethod.LocalSTA, ip="192.168.8.181")
+        conn = UnitreeWebRTCConnection(WebRTCConnectionMethod.LocalSTA)
         # conn = UnitreeWebRTCConnection(WebRTCConnectionMethod.LocalSTA, serialNumber="B42D2000XXXXXXXX")
         # conn = UnitreeWebRTCConnection(WebRTCConnectionMethod.Remote, serialNumber="B42D2000XXXXXXXX", username="email@gmail.com", password="pass")
         # conn = UnitreeWebRTCConnection(WebRTCConnectionMethod.LocalAP)

--- a/examples/go2/video/camera_stream/display_video_channel.py
+++ b/examples/go2/video/camera_stream/display_video_channel.py
@@ -22,7 +22,7 @@ def main():
     frame_queue = Queue()
 
     # Choose a connection method (uncomment the correct one)
-    conn = UnitreeWebRTCConnection(WebRTCConnectionMethod.LocalSTA, ip="192.168.8.181")
+    conn = UnitreeWebRTCConnection(WebRTCConnectionMethod.LocalSTA)
     # conn = UnitreeWebRTCConnection(WebRTCConnectionMethod.LocalSTA, serialNumber="B42D2000XXXXXXXX")
     # conn = UnitreeWebRTCConnection(WebRTCConnectionMethod.Remote, serialNumber="B42D2000XXXXXXXX", username="email@gmail.com", password="pass")
     # conn = UnitreeWebRTCConnection(WebRTCConnectionMethod.LocalAP)

--- a/unitree_webrtc_connect/webrtc_driver.py
+++ b/unitree_webrtc_connect/webrtc_driver.py
@@ -2,6 +2,7 @@ import asyncio
 import logging
 import json
 import sys
+import os
 from aiortc import RTCPeerConnection, RTCSessionDescription, RTCIceServer, RTCConfiguration
 from aiortc.contrib.media import MediaPlayer
 from .unitree_auth import send_sdp_to_local_peer, send_sdp_to_remote_peer
@@ -19,7 +20,7 @@ class UnitreeWebRTCConnection:
     def __init__(self, connectionMethod: WebRTCConnectionMethod, serialNumber=None, ip=None, username=None, password=None) -> None:
         self.pc = None
         self.sn = serialNumber
-        self.ip = ip
+        self.ip = ip if ip else os.getenv("ROBOT_IP")
         self.connectionMethod = connectionMethod
         self.isConnected = False
         self.token = fetch_token(username, password) if username and password else ""


### PR DESCRIPTION
Allows optionally setting the robot IP without modifying the Python source code using an environment variable `ROBOT_IP`. This approach is already used in https://github.com/abizovnuralem/go2_ros2_sdk